### PR TITLE
Remove D-key shortcuts and improve help modal

### DIFF
--- a/components/dice-roller/HelpModal.tsx
+++ b/components/dice-roller/HelpModal.tsx
@@ -13,155 +13,87 @@ interface HelpModalProps {
 export function HelpModal({ isOpen, onClose }: HelpModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Keyboard Shortcuts</DialogTitle>
         </DialogHeader>
         
         <div className="space-y-6">
           <section>
-            <h3 className="text-lg font-semibold mb-3">Quick d20 Rolls</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">SPACE</kbd>
-                <span>Roll 1d20</span>
+            <h3 className="text-lg font-semibold mb-3">Rolling Dice</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">ENTER</kbd>
+                <span className="ml-2">Roll 1d20 or dice pool</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">5 ENTER</kbd>
-                <span>Roll 1d20+5</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">Numbers</kbd>
+                <span className="ml-2">Set positive modifier</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">20 ENTER</kbd>
-                <span>Roll 1d20+20</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">- Numbers</kbd>
+                <span className="ml-2">Set negative modifier</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">- 2 ENTER</kbd>
-                <span>Roll 1d20-2</span>
-              </div>
-            </div>
-          </section>
-
-          <section>
-            <h3 className="text-lg font-semibold mb-3">Modifiers</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">5</kbd>
-                <span>Immediately set +5</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">- 3</kbd>
-                <span>Immediately set -3</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">BACKSPACE</kbd>
-                <span>Remove last digit</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">ENTER</kbd>
-                <span>Roll with modifier</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">BACKSPACE</kbd>
+                <span className="ml-2">Edit modifier or remove dice</span>
               </div>
             </div>
           </section>
 
           <section>
-            <h3 className="text-lg font-semibold mb-3">Command+Number (Add Dice)</h3>
+            <h3 className="text-lg font-semibold mb-3">Adding Multiple Dice</h3>
             <p className="text-sm text-muted-foreground mb-3">Each press adds exactly 1 die. Press multiple times to add multiple dice.</p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 1</kbd>
-                <span>Add 1d20</span>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 1</kbd>
+                <span className="ml-2">Add 1d20</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 2</kbd>
-                <span>Add 1d12</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 2</kbd>
+                <span className="ml-2">Add 1d12</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 3</kbd>
-                <span>Add 1d10</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 3</kbd>
+                <span className="ml-2">Add 1d10</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 4</kbd>
-                <span>Add 1d8</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 4</kbd>
+                <span className="ml-2">Add 1d8</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 5</kbd>
-                <span>Add 1d6</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 5</kbd>
+                <span className="ml-2">Add 1d6</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 6</kbd>
-                <span>Add 1d4</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 6</kbd>
+                <span className="ml-2">Add 1d4</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">⌘ 7</kbd>
-                <span>Add 1d100</span>
-              </div>
-            </div>
-          </section>
-
-          <section>
-            <h3 className="text-lg font-semibold mb-3">Die Types</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D 4</kbd>
-                <span>Add 1d4</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D 6</kbd>
-                <span>Add 1d6</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D 8</kbd>
-                <span>Add 1d8</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D 1</kbd>
-                <span>Add 1d10</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D 2</kbd>
-                <span>Add 1d12</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D 0</kbd>
-                <span>Add 1d100</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">D D</kbd>
-                <span>Return to d20 mode</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">Shift + D</kbd>
-                <span>Change die type only</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">⌘ 7</kbd>
+                <span className="ml-2">Add 1d100</span>
               </div>
             </div>
           </section>
 
           <section>
-            <h3 className="text-lg font-semibold mb-3">Actions</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">ENTER</kbd>
-                <span>Roll dice pool</span>
+            <h3 className="text-lg font-semibold mb-3">Other Actions</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">R</kbd>
+                <span className="ml-2">Reroll last roll</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">R</kbd>
-                <span>Reroll last roll</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">ESC</kbd>
+                <span className="ml-2">Clear dice pool</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">ESC</kbd>
-                <span>Clear dice pool</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">C</kbd>
+                <span className="ml-2">Copy last result</span>
               </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">BACKSPACE</kbd>
-                <span>Remove last dice group</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">H</kbd>
-                <span>Toggle history</span>
-              </div>
-              <div className="flex justify-between">
-                <kbd className="px-2 py-1 bg-muted rounded font-mono">C</kbd>
-                <span>Copy last result</span>
+              <div className="flex justify-between items-center">
+                <kbd className="px-2 py-1 bg-muted rounded font-mono whitespace-nowrap">?</kbd>
+                <span className="ml-2">Toggle this help</span>
               </div>
             </div>
           </section>
@@ -170,19 +102,19 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
             <h3 className="text-lg font-semibold mb-3">Examples</h3>
             <div className="space-y-2 text-sm">
               <div>
-                <strong>Roll 1d20+5:</strong> Press <kbd className="px-1 py-0.5 bg-muted rounded font-mono">5</kbd> then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd>
+                <strong>Simple roll:</strong> Press <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd> to roll 1d20
               </div>
               <div>
-                <strong>Roll 1d20+23:</strong> Press <kbd className="px-1 py-0.5 bg-muted rounded font-mono">2</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">3</kbd> then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd>
+                <strong>Roll with modifier:</strong> Type <kbd className="px-1 py-0.5 bg-muted rounded font-mono">5</kbd> then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd> for 1d20+5
               </div>
               <div>
-                <strong>Edit modifier:</strong> Type <kbd className="px-1 py-0.5 bg-muted rounded font-mono">1</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">2</kbd>, then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">BACKSPACE</kbd> to get +1
+                <strong>Roll with negative:</strong> Type <kbd className="px-1 py-0.5 bg-muted rounded font-mono">-</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">2</kbd> then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd> for 1d20-2
               </div>
               <div>
-                <strong>Add 3d6:</strong> Press <kbd className="px-1 py-0.5 bg-muted rounded font-mono">⌘</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">5</kbd> three times, then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">SPACE</kbd>
+                <strong>Multiple dice:</strong> Press <kbd className="px-1 py-0.5 bg-muted rounded font-mono">⌘</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">5</kbd> three times for 3d6, then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd>
               </div>
               <div>
-                <strong>Roll 2d20+1d8-2:</strong> Press <kbd className="px-1 py-0.5 bg-muted rounded font-mono">⌘</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">1</kbd> twice, then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">⌘</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">4</kbd> once, then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">-</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">2</kbd>, then <kbd className="px-1 py-0.5 bg-muted rounded font-mono">SPACE</kbd>
+                <strong>Complex roll:</strong> <kbd className="px-1 py-0.5 bg-muted rounded font-mono">⌘</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">1</kbd> twice + <kbd className="px-1 py-0.5 bg-muted rounded font-mono">⌘</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">4</kbd> + <kbd className="px-1 py-0.5 bg-muted rounded font-mono">-</kbd><kbd className="px-1 py-0.5 bg-muted rounded font-mono">2</kbd> + <kbd className="px-1 py-0.5 bg-muted rounded font-mono">ENTER</kbd> for 2d20+1d8-2
               </div>
             </div>
           </section>

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,5 @@
 import { useEffect, useCallback } from 'react';
 import { DiceRollerState } from '@/lib/dice-types';
-import { DIE_SHORTCUTS } from '@/lib/dice-types';
 
 interface KeyboardActions {
   addDice: (dieType: any, quantity: number) => void;
@@ -31,8 +30,8 @@ export function useKeyboardShortcuts(state: DiceRollerState, actions: KeyboardAc
 
     // Prevent default for most keys we handle
     const handledKeys = [
-      ' ', 'enter', 'escape', 'backspace', 'h', 'r', 'c', '?',
-      '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', 'd'
+      'enter', 'escape', 'backspace', 'r', 'c', '?',
+      '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-'
     ];
     
     if (handledKeys.includes(key)) {
@@ -42,7 +41,6 @@ export function useKeyboardShortcuts(state: DiceRollerState, actions: KeyboardAc
 
     switch (key) {
       // Roll dice
-      case ' ':
       case 'enter':
         if (state.quickMode && state.dicePool.length === 0) {
           actions.rollQuickD20(1);
@@ -91,10 +89,6 @@ export function useKeyboardShortcuts(state: DiceRollerState, actions: KeyboardAc
         }
         break;
 
-      // Die type selection with D prefix
-      case 'd':
-        // Wait for next keypress to get die type
-        break;
 
       // Clear pool
       case 'escape':
@@ -117,10 +111,6 @@ export function useKeyboardShortcuts(state: DiceRollerState, actions: KeyboardAc
         actions.rerollLast();
         break;
 
-      // Toggle history
-      case 'h':
-        actions.toggleHistory();
-        break;
 
       // Toggle help
       case '?':
@@ -136,47 +126,12 @@ export function useKeyboardShortcuts(state: DiceRollerState, actions: KeyboardAc
     }
   }, [state, actions]);
 
-  // Handle D + number combinations
-  const handleDieCombination = useCallback((event: KeyboardEvent) => {
-    const key = event.key.toLowerCase();
-    
-    if (key === 'd') {
-      // Set up listener for next keypress
-      const handleNextKey = (nextEvent: KeyboardEvent) => {
-        const nextKey = nextEvent.key;
-        if (DIE_SHORTCUTS[nextKey]) {
-          const dieType = DIE_SHORTCUTS[nextKey];
-          if (event.shiftKey) {
-            // Just change die type
-            actions.setDieType(dieType);
-          } else {
-            // Add one die of this type
-            actions.addDice(dieType, 1);
-          }
-          nextEvent.preventDefault();
-        } else if (nextKey === 'd') {
-          // DD - return to d20 mode
-          actions.setDieType('d20');
-          actions.clearDicePool();
-          nextEvent.preventDefault();
-        }
-        document.removeEventListener('keydown', handleNextKey);
-      };
-      
-      document.addEventListener('keydown', handleNextKey);
-      setTimeout(() => {
-        document.removeEventListener('keydown', handleNextKey);
-      }, 1000); // Remove listener after 1 second
-    }
-  }, [actions]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyPress);
-    document.addEventListener('keydown', handleDieCombination);
     
     return () => {
       document.removeEventListener('keydown', handleKeyPress);
-      document.removeEventListener('keydown', handleDieCombination);
     };
-  }, [handleKeyPress, handleDieCombination]);
+  }, [handleKeyPress]);
 }

--- a/lib/dice-types.ts
+++ b/lib/dice-types.ts
@@ -49,11 +49,3 @@ export const DIE_FACES: Record<DieType, number> = {
   'd100': 100,
 };
 
-export const DIE_SHORTCUTS: Record<string, DieType> = {
-  '4': 'd4',
-  '6': 'd6',
-  '8': 'd8',
-  '1': 'd10',
-  '2': 'd12',
-  '0': 'd100',
-};


### PR DESCRIPTION
- Remove all D+number keybinds (D4, D6, D8, D1, D2, D0)
- Remove DD and Shift+D keybinds
- Remove SPACE and H keybinds as requested
- Restructure help modal for better clarity
- Improve modal layout and prevent text wrapping
- Update examples to be more general and useful

🤖 Generated with [Claude Code](https://claude.ai/code)